### PR TITLE
Add simple tilemap and encounter logic

### DIFF
--- a/vanadiel_rpg/game/Cargo.toml
+++ b/vanadiel_rpg/game/Cargo.toml
@@ -9,6 +9,7 @@ bevy_ecs_tilemap = "0.16"
 serde = { version = "1", features = ["derive"] }
 ron = "0.8"
 anyhow = "1"
+rand = "0.8"
 
 [features]
 default = []

--- a/vanadiel_rpg/game/src/main.rs
+++ b/vanadiel_rpg/game/src/main.rs
@@ -4,6 +4,7 @@ use bevy::prelude::*;
 use bevy::window::PresentMode;
 use bevy::render::texture::ImagePlugin;
 use bevy::diagnostic::FrameTimeDiagnosticsPlugin;
+use bevy_ecs_tilemap::TilemapPlugin;
 
 mod plugins {
     pub mod core;
@@ -33,6 +34,7 @@ fn main() {
                 .set(ImagePlugin::default_nearest()),
         )
         .add_plugins(FrameTimeDiagnosticsPlugin::default())
+        .add_plugins(TilemapPlugin)
         .add_plugins(CorePlugin)
         .add_plugins(MapPlugin)
         .add_plugins(MovementPlugin)

--- a/vanadiel_rpg/game/src/plugins/combat.rs
+++ b/vanadiel_rpg/game/src/plugins/combat.rs
@@ -2,6 +2,12 @@
 
 use bevy::prelude::*;
 
+use super::core::GameState;
+
+/// Event triggered when a random encounter occurs.
+#[derive(Event, Default)]
+pub struct EncounterEvent;
+
 /// Marker component for combat entities.
 #[derive(Component)]
 pub struct Combatant;
@@ -11,10 +17,42 @@ pub struct CombatPlugin;
 
 impl Plugin for CombatPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(OnEnter(super::core::GameState::Battle), start_battle);
+        app.add_event::<EncounterEvent>()
+            .add_systems(Update, handle_encounter.run_if(in_state(GameState::Exploration)))
+            .add_systems(OnEnter(GameState::Battle), start_battle)
+            .add_systems(Update, exit_battle.run_if(in_state(GameState::Battle)))
+            .add_systems(OnExit(GameState::Battle), cleanup_battle);
     }
 }
 
-fn start_battle() {
-    // TODO: initialize battle state
+fn start_battle(mut commands: Commands) {
+    // Spawn a placeholder enemy sprite
+    commands.spawn((
+        Sprite::from_color(Color::RED, Vec2::splat(16.0)),
+        Combatant,
+    ));
+}
+
+fn handle_encounter(
+    mut events: EventReader<EncounterEvent>,
+    mut next_state: ResMut<NextState<GameState>>,
+) {
+    if events.read().next().is_some() {
+        next_state.set(GameState::Battle);
+    }
+}
+
+fn exit_battle(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut next_state: ResMut<NextState<GameState>>,
+) {
+    if keyboard.just_pressed(KeyCode::Escape) {
+        next_state.set(GameState::Exploration);
+    }
+}
+
+fn cleanup_battle(mut commands: Commands, query: Query<Entity, With<Combatant>>) {
+    for entity in &query {
+        commands.entity(entity).despawn_recursive();
+    }
 }

--- a/vanadiel_rpg/game/src/plugins/map.rs
+++ b/vanadiel_rpg/game/src/plugins/map.rs
@@ -2,6 +2,7 @@
 
 use bevy::prelude::*;
 use bevy::color::palettes::basic::YELLOW;
+use bevy_ecs_tilemap::prelude::*;
 
 use super::movement::Player;
 
@@ -23,8 +24,40 @@ fn spawn_player(mut commands: Commands) {
     commands.spawn((Sprite::from_color(YELLOW, Vec2::splat(16.0)), Player));
 }
 
-fn load_map() {
-    // TODO: load assets/maps/dev_room.tmx via bevy_ecs_tilemap
+fn load_map(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // Spawn a simple 10x10 tilemap using a single white tile texture
+    let map_size = TilemapSize { x: 10, y: 10 };
+    let tile_size = TilemapTileSize { x: 32.0, y: 32.0 };
+    let grid_size = tile_size.into();
+    let tilemap_entity = commands.spawn_empty().id();
+    let mut tile_storage = TileStorage::empty(map_size);
+
+    for x in 0..map_size.x {
+        for y in 0..map_size.y {
+            let tile_pos = TilePos { x, y };
+            let tile_entity = commands
+                .spawn(TileBundle {
+                    position: tile_pos,
+                    tilemap_id: TilemapId(tilemap_entity),
+                    ..Default::default()
+                })
+                .id();
+            commands.entity(tilemap_entity).add_child(tile_entity);
+            tile_storage.set(&tile_pos, tile_entity);
+        }
+    }
+
+    let texture: Handle<Image> = asset_server.load("tiles.png");
+
+    commands.entity(tilemap_entity).insert(TilemapBundle {
+        grid_size,
+        size: map_size,
+        storage: tile_storage,
+        texture: TilemapTexture::Single(texture),
+        tile_size,
+        map_type: TilemapType::Square,
+        ..Default::default()
+    });
 }
 
 fn camera_follow(

--- a/vanadiel_rpg/game/src/plugins/movement.rs
+++ b/vanadiel_rpg/game/src/plugins/movement.rs
@@ -2,13 +2,20 @@
 
 use bevy::prelude::*;
 use bevy::input::ButtonInput;
+use rand::random;
+
+use super::combat::EncounterEvent;
+use super::core::GameState;
 
 /// Plugin handling movement logic.
 pub struct MovementPlugin;
 
 impl Plugin for MovementPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, keyboard_movement);
+        app.add_systems(
+            Update,
+            keyboard_movement.run_if(in_state(GameState::Exploration)),
+        );
     }
 }
 
@@ -18,6 +25,7 @@ pub struct Player;
 fn keyboard_movement(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut query: Query<&mut Transform, With<Player>>,
+    mut encounter_writer: EventWriter<EncounterEvent>,
 ) {
     for mut transform in &mut query {
         let mut delta = Vec3::ZERO;
@@ -36,7 +44,10 @@ fn keyboard_movement(
         if delta != Vec3::ZERO {
             // TODO: add collision checking
             transform.translation += delta;
-            // TODO: integrate random-encounter trigger
+            // very basic encounter chance
+            if random::<f32>() < 0.05 {
+                encounter_writer.send(EncounterEvent);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- create a minimal tilemap during startup
- allow player movement only in exploration state
- send `EncounterEvent` from movement to begin battle
- spawn placeholder enemy sprite during battles
- enable TilemapPlugin and add `rand` dependency

## Testing
- `cargo build -p game` *(fails: alsa-sys missing system library)*
- `cargo fmt --all` *(fails: rustfmt missing)*
- `cargo clippy --all-targets -- -D warnings` *(fails: clippy missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e0204c1448323a92bae4ff9e1f5b9