### PR TITLE
Introduce tutorial quest and interactions

### DIFF
--- a/vanadiel_rpg/.gitignore
+++ b/vanadiel_rpg/.gitignore
@@ -14,3 +14,5 @@ Cargo.lock
 # Fetch-on-demand assets
 assets/**/*.png
 assets/**/*.ogg
+game/assets/textures/*.png
+game/assets/audio/*.ogg

--- a/vanadiel_rpg/docs/design.md
+++ b/vanadiel_rpg/docs/design.md
@@ -141,7 +141,17 @@ Cut-scenes for main story events are essentially extended dialogue sequences pos
 
 Technically, each quest has conditions and flags in the game’s state. We maintain a data structure for quests (with fields like status, objectives completed, etc.). Dialogue or item interactions can update these flags. For instance, if Quest A requires you to bring an item to NPC X, when you talk to NPC X with the item in inventory, a special dialogue branch triggers, the item is removed, and the quest marked complete, giving a reward.
 
+Quest data lives in `game/assets/quests/` as small RON files. NPC dialogue text is stored under `game/assets/dialogue/`. Each quest file defines an `id`, `name`, and `description` used by the quest log. Dialogue files are plain text shown line by line when the player interacts with an NPC. This layout keeps content data-driven so new quests or conversations can be added without touching code.
+
 The quest journal UI is implemented as a menu the player can open. It shows active quests with a short summary and maybe a hint for next step. We ensure that main quests are clearly indicated to guide the player through the story, while side quests are optional and need discovery (just like FFXI often required talking to the right NPC to start a quest).
+
+```
+game/
+  assets/
+    quests/     # `.ron` quest definitions
+    dialogue/   # text files for NPC conversations
+```
+This folder structure keeps narrative assets organized and makes it easy to drop in new quest or dialogue files later.
 
 ### Additional Systems
 

--- a/vanadiel_rpg/game/assets/dialogue/elder.txt
+++ b/vanadiel_rpg/game/assets/dialogue/elder.txt
@@ -1,0 +1,2 @@
+Welcome to our village, traveler.
+Bring me a healing herb from the forest and I'll show you around.

--- a/vanadiel_rpg/game/assets/quests/tutorial_herb.ron
+++ b/vanadiel_rpg/game/assets/quests/tutorial_herb.ron
@@ -1,0 +1,5 @@
+(
+    id: "tutorial_herb",
+    name: "A Healer's Request",
+    description: "The town elder needs a healing herb from the forest outside town.",
+)

--- a/vanadiel_rpg/game/src/main.rs
+++ b/vanadiel_rpg/game/src/main.rs
@@ -11,6 +11,8 @@ mod plugins {
     pub mod map;
     pub mod movement;
     pub mod combat;
+    pub mod interaction;
+    pub mod quest;
     pub mod ui;
     pub mod loading;
     pub mod sprite;
@@ -19,9 +21,11 @@ mod plugins {
 use plugins::{
     combat::CombatPlugin,
     core::CorePlugin,
+    interaction::InteractionPlugin,
     loading::LoadingPlugin,
     map::MapPlugin,
     movement::MovementPlugin,
+    quest::QuestPlugin,
     sprite::SpritePlugin,
     ui::UiPlugin,
 };
@@ -48,6 +52,8 @@ fn main() {
         .add_plugins(CorePlugin)
         .add_plugins(LoadingPlugin)
         .add_plugins(MapPlugin)
+        .add_plugins(InteractionPlugin)
+        .add_plugins(QuestPlugin)
         .add_plugins(SpritePlugin)
         .add_plugins(MovementPlugin)
         .add_plugins(CombatPlugin)

--- a/vanadiel_rpg/game/src/plugins/interaction.rs
+++ b/vanadiel_rpg/game/src/plugins/interaction.rs
@@ -1,0 +1,52 @@
+//! Basic interaction detection and event types.
+
+use bevy::prelude::*;
+
+use super::movement::Player;
+
+/// Component for entities that can be interacted with.
+#[derive(Component, Clone)]
+pub struct Interactable {
+    /// Unique identifier for the interactive object.
+    pub id: String,
+}
+
+/// Event fired when the player interacts with an [`Interactable`].
+#[derive(Event)]
+pub struct InteractEvent {
+    /// The id of the interacted object.
+    pub id: String,
+}
+
+/// Plugin handling player interaction logic.
+pub struct InteractionPlugin;
+
+impl Plugin for InteractionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<InteractEvent>()
+            .add_systems(Update, player_interactions);
+    }
+}
+
+fn player_interactions(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    player_query: Query<&Transform, With<Player>>,
+    interactables: Query<(&Transform, &Interactable)>,
+    mut writer: EventWriter<InteractEvent>,
+) {
+    if !keyboard.just_pressed(KeyCode::Space) {
+        return;
+    }
+
+    let Ok(player_t) = player_query.get_single() else { return; };
+    let player_pos = player_t.translation.truncate();
+
+    for (transform, interactable) in &interactables {
+        let pos = transform.translation.truncate();
+        if player_pos.distance(pos) < 20.0 {
+            writer.send(InteractEvent {
+                id: interactable.id.clone(),
+            });
+        }
+    }
+}

--- a/vanadiel_rpg/game/src/plugins/map.rs
+++ b/vanadiel_rpg/game/src/plugins/map.rs
@@ -6,6 +6,7 @@ use bevy_ecs_tilemap::prelude::*;
 
 use super::movement::Player;
 use super::loading::{AppState, GameAssets};
+use super::interaction::Interactable;
 
 /// Plugin responsible for map management.
 pub struct MapPlugin;
@@ -32,6 +33,7 @@ fn spawn_npc(mut commands: Commands) {
         Transform::from_translation(Vec3::new(96.0, 96.0, 1.0)),
         GlobalTransform::default(),
         Npc,
+        Interactable { id: "elder".to_string() },
     ));
 }
 
@@ -75,6 +77,14 @@ fn load_map(mut commands: Commands, assets: Res<GameAssets>) {
         map_type: TilemapType::Square,
         ..Default::default()
     });
+
+    // Herb spawn for tutorial quest
+    commands.spawn((
+        Sprite::from_color(Color::GREEN, Vec2::splat(16.0)),
+        Transform::from_translation(Vec3::new(160.0, 32.0, 1.0)),
+        GlobalTransform::default(),
+        Interactable { id: "herb".to_string() },
+    ));
 }
 
 fn camera_follow(

--- a/vanadiel_rpg/game/src/plugins/quest.rs
+++ b/vanadiel_rpg/game/src/plugins/quest.rs
@@ -1,0 +1,105 @@
+//! Simple quest state management.
+
+use std::collections::HashMap;
+
+use bevy::prelude::*;
+use serde::Deserialize;
+
+use super::interaction::InteractEvent;
+
+/// Status of a quest.
+#[derive(Clone, Copy, PartialEq, Eq, Deserialize)]
+pub enum QuestStatus {
+    /// Quest not yet accepted.
+    NotStarted,
+    /// Quest accepted but objectives incomplete.
+    InProgress,
+    /// Quest fully completed.
+    Completed,
+}
+
+impl Default for QuestStatus {
+    fn default() -> Self {
+        QuestStatus::NotStarted
+    }
+}
+
+/// Persistent quest log storing all quest states.
+#[derive(Resource, Default)]
+pub struct QuestLog {
+    /// Map of quest id to its current status.
+    pub quests: HashMap<String, QuestStatus>,
+    /// Progress flag for the tutorial herb objective.
+    pub herb_collected: bool,
+}
+
+#[derive(Deserialize)]
+struct QuestDefinition {
+    id: String,
+    name: String,
+    description: String,
+}
+
+/// Plugin registering the quest system.
+pub struct QuestPlugin;
+
+impl Plugin for QuestPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<QuestLog>()
+            .add_systems(Startup, setup_quest)
+            .add_systems(Update, quest_interactions);
+    }
+}
+
+const TUTORIAL_QUEST: &str = include_str!("../assets/quests/tutorial_herb.ron");
+
+fn setup_quest(mut log: ResMut<QuestLog>) {
+    let def: QuestDefinition = ron::from_str(TUTORIAL_QUEST).expect("valid quest");
+    log.quests.insert(def.id, QuestStatus::NotStarted);
+}
+
+fn quest_interactions(
+    mut events: EventReader<InteractEvent>,
+    mut log: ResMut<QuestLog>,
+) {
+    for ev in events.read() {
+        match ev.id.as_str() {
+            "elder" => handle_elder(&mut log),
+            "herb" => handle_herb(&mut log),
+            _ => {}
+        }
+    }
+}
+
+fn handle_elder(log: &mut QuestLog) {
+    let status = log
+        .quests
+        .entry("tutorial_herb".into())
+        .or_insert(QuestStatus::NotStarted);
+    match *status {
+        QuestStatus::NotStarted => {
+            info!("Elder: Please fetch a healing herb from the forest.");
+            *status = QuestStatus::InProgress;
+        }
+        QuestStatus::InProgress => {
+            if log.herb_collected {
+                info!("Elder: Thank you for the herb! Rest at our inn anytime.");
+                *status = QuestStatus::Completed;
+            } else {
+                info!("Elder: The herb grows just outside town.");
+            }
+        }
+        QuestStatus::Completed => {
+            info!("Elder: Good to see you again, hero.");
+        }
+    }
+}
+
+fn handle_herb(log: &mut QuestLog) {
+    if let Some(status) = log.quests.get(&"tutorial_herb".to_string()) {
+        if *status == QuestStatus::InProgress && !log.herb_collected {
+            info!("You picked up the healing herb.");
+            log.herb_collected = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add interaction plugin for detecting player actions
- implement a simple quest system and tutorial quest
- spawn herb and elder NPC interactables on the map
- document asset folders for quests and dialogue
- ignore local asset downloads in `.gitignore`

## Testing
- `bash vanadiel_rpg/scripts/pre_commit.sh` *(fails: 'cargo-fmt' not installed)*
- `cargo check -p game` *(fails: missing system library `alsa`)*

------
https://chatgpt.com/codex/tasks/task_e_686f003977c48323ac0483090f560388