### PR TITLE
Add Briarwood starter area and tutorial NPCs

### DIFF
--- a/vanadiel_rpg/game/assets/dialogue/child.txt
+++ b/vanadiel_rpg/game/assets/dialogue/child.txt
@@ -1,0 +1,1 @@
+I saw something shiny near the trees! Maybe it's what the elder needs.

--- a/vanadiel_rpg/game/assets/dialogue/goblin.txt
+++ b/vanadiel_rpg/game/assets/dialogue/goblin.txt
@@ -1,0 +1,1 @@
+*The goblin snarls, clutching a crude blade.*

--- a/vanadiel_rpg/game/assets/dialogue/guard.txt
+++ b/vanadiel_rpg/game/assets/dialogue/guard.txt
@@ -1,0 +1,1 @@
+Hold your weapon steady, traveler. The Orcs watch these woods.

--- a/vanadiel_rpg/game/assets/dialogue/shopkeeper.txt
+++ b/vanadiel_rpg/game/assets/dialogue/shopkeeper.txt
@@ -1,0 +1,1 @@
+Fresh supplies! Don't wander into the forest without a potion.

--- a/vanadiel_rpg/game/src/main.rs
+++ b/vanadiel_rpg/game/src/main.rs
@@ -16,11 +16,13 @@ mod plugins {
     pub mod ui;
     pub mod loading;
     pub mod sprite;
+    pub mod starter_area;
 }
 
 use plugins::{
     combat::CombatPlugin,
     core::CorePlugin,
+    starter_area::StarterAreaPlugin,
     interaction::InteractionPlugin,
     loading::LoadingPlugin,
     map::MapPlugin,
@@ -52,6 +54,7 @@ fn main() {
         .add_plugins(CorePlugin)
         .add_plugins(LoadingPlugin)
         .add_plugins(MapPlugin)
+        .add_plugins(StarterAreaPlugin)
         .add_plugins(InteractionPlugin)
         .add_plugins(QuestPlugin)
         .add_plugins(SpritePlugin)

--- a/vanadiel_rpg/game/src/plugins/quest.rs
+++ b/vanadiel_rpg/game/src/plugins/quest.rs
@@ -6,6 +6,13 @@ use bevy::prelude::*;
 use serde::Deserialize;
 
 use super::interaction::InteractEvent;
+use super::combat::EncounterEvent;
+
+const DIALOG_ELDER: &str = include_str!("../assets/dialogue/elder.txt");
+const DIALOG_GUARD: &str = include_str!("../assets/dialogue/guard.txt");
+const DIALOG_SHOPKEEP: &str = include_str!("../assets/dialogue/shopkeeper.txt");
+const DIALOG_CHILD: &str = include_str!("../assets/dialogue/child.txt");
+const DIALOG_GOBLIN: &str = include_str!("../assets/dialogue/goblin.txt");
 
 /// Status of a quest.
 #[derive(Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -61,11 +68,19 @@ fn setup_quest(mut log: ResMut<QuestLog>) {
 fn quest_interactions(
     mut events: EventReader<InteractEvent>,
     mut log: ResMut<QuestLog>,
+    mut encounter_writer: EventWriter<EncounterEvent>,
 ) {
     for ev in events.read() {
         match ev.id.as_str() {
             "elder" => handle_elder(&mut log),
             "herb" => handle_herb(&mut log),
+            "goblin" => {
+                info!("{}", DIALOG_GOBLIN);
+                encounter_writer.send(EncounterEvent)
+            }
+            "guard" => info!("{}", DIALOG_GUARD),
+            "shopkeeper" => info!("{}", DIALOG_SHOPKEEP),
+            "child" => info!("{}", DIALOG_CHILD),
             _ => {}
         }
     }
@@ -78,7 +93,7 @@ fn handle_elder(log: &mut QuestLog) {
         .or_insert(QuestStatus::NotStarted);
     match *status {
         QuestStatus::NotStarted => {
-            info!("Elder: Please fetch a healing herb from the forest.");
+            info!("{}", DIALOG_ELDER);
             *status = QuestStatus::InProgress;
         }
         QuestStatus::InProgress => {

--- a/vanadiel_rpg/game/src/plugins/starter_area.rs
+++ b/vanadiel_rpg/game/src/plugins/starter_area.rs
@@ -1,0 +1,53 @@
+//! Spawns the Briarwood Village starter area.
+use bevy::prelude::*;
+
+use super::interaction::Interactable;
+use super::loading::AppState;
+
+/// Plugin for Briarwood Village setup.
+pub struct StarterAreaPlugin;
+
+impl Plugin for StarterAreaPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(OnEnter(AppState::InGame), spawn_area);
+    }
+}
+
+fn spawn_area(mut commands: Commands) {
+    // Elder NPC
+    commands.spawn((
+        Sprite::from_color(Color::rgb(0.3, 0.5, 1.0), Vec2::splat(16.0)),
+        Transform::from_xyz(96.0, 96.0, 1.0),
+        GlobalTransform::default(),
+        Interactable { id: "elder".to_string() },
+    ));
+    // Guard NPC
+    commands.spawn((
+        Sprite::from_color(Color::rgb(0.6, 0.6, 0.8), Vec2::splat(16.0)),
+        Transform::from_xyz(64.0, 64.0, 1.0),
+        GlobalTransform::default(),
+        Interactable { id: "guard".to_string() },
+    ));
+    // Shopkeeper NPC
+    commands.spawn((
+        Sprite::from_color(Color::rgb(0.8, 0.7, 0.4), Vec2::splat(16.0)),
+        Transform::from_xyz(128.0, 64.0, 1.0),
+        GlobalTransform::default(),
+        Interactable { id: "shopkeeper".to_string() },
+    ));
+    // Curious child NPC
+    commands.spawn((
+        Sprite::from_color(Color::rgb(0.9, 0.8, 0.8), Vec2::splat(16.0)),
+        Transform::from_xyz(96.0, 32.0, 1.0),
+        GlobalTransform::default(),
+        Interactable { id: "child".to_string() },
+    ));
+    // Goblin target in the forest
+    commands.spawn((
+        Sprite::from_color(Color::rgb(0.7, 0.2, 0.2), Vec2::splat(16.0)),
+        Transform::from_xyz(160.0, 32.0, 1.0),
+        GlobalTransform::default(),
+        Interactable { id: "goblin".to_string() },
+    ));
+}
+


### PR DESCRIPTION
## Summary
- add `StarterAreaPlugin` spawning Briarwood Village NPCs
- include dialog text for guard, shopkeeper, child and goblin
- load dialogues from quest system and trigger battles with goblin
- register new plugin in `main.rs`

## Testing
- `./scripts/pre_commit.sh` *(fails: 'cargo-fmt' not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f0c42f85c8323a72e96c8394fceb3