### PR TITLE
Implement basic skillchain combat

### DIFF
--- a/vanadiel_rpg/game/Cargo.toml
+++ b/vanadiel_rpg/game/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1", features = ["derive"] }
 ron = "0.8"
 anyhow = "1"
 rand = "0.8"
+smallvec = "1.11"
 
 [features]
 default = []

--- a/vanadiel_rpg/game/assets/data/skillchain_table.toml
+++ b/vanadiel_rpg/game/assets/data/skillchain_table.toml
@@ -1,0 +1,19 @@
+[[chains]]
+properties = ["Scission", "Detonation"]
+level = 1
+elements = ["Earth"]
+
+[[chains]]
+properties = ["Liquefaction", "Impaction"]
+level = 2
+elements = ["Fire", "Light"]
+
+[[chains]]
+properties = ["Fragmentation", "Gravitation"]
+level = 3
+elements = ["Dark"]
+
+[[chains]]
+properties = ["Light", "Light"]
+level = 4
+elements = ["Fire", "Wind", "Lightning", "Light"]

--- a/vanadiel_rpg/game/assets/data/spells.toml
+++ b/vanadiel_rpg/game/assets/data/spells.toml
@@ -1,0 +1,9 @@
+[[spells]]
+name = "Fire"
+element = "Fire"
+cast_time = 3
+
+[[spells]]
+name = "Stone"
+element = "Earth"
+cast_time = 3

--- a/vanadiel_rpg/game/assets/data/weapon_skills.toml
+++ b/vanadiel_rpg/game/assets/data/weapon_skills.toml
@@ -1,0 +1,9 @@
+[[weapon_skills]]
+name = "Burning Blade"
+tp_cost = 1000
+properties = ["Scission", "Liquefaction"]
+
+[[weapon_skills]]
+name = "Flat Blade"
+tp_cost = 1000
+properties = ["Detonation", "Impaction"]

--- a/vanadiel_rpg/game/assets/quests/quest_001_skillchain.toml
+++ b/vanadiel_rpg/game/assets/quests/quest_001_skillchain.toml
@@ -1,0 +1,2 @@
+objective = ["Perform any Level 1 Skillchain", "Magic Burst with the matching element"]
+reward = { exp = 150, item = "Minor Ether" }

--- a/vanadiel_rpg/game/src/combat/components.rs
+++ b/vanadiel_rpg/game/src/combat/components.rs
@@ -1,0 +1,83 @@
+//! Components and data types for the combat system.
+
+use bevy::prelude::*;
+use smallvec::SmallVec;
+
+/// Elements used by magic and skillchains.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum Element {
+    Fire,
+    Ice,
+    Wind,
+    Earth,
+    Lightning,
+    Water,
+    Light,
+    Dark,
+}
+
+/// Skillchain properties possessed by weapon skills.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum ScProp {
+    Transfixion,
+    Compression,
+    Liquefaction,
+    Scission,
+    Reverberation,
+    Detonation,
+    Induration,
+    Impaction,
+    Fragmentation,
+    Distortion,
+    Fusion,
+    Gravitation,
+    Light,
+    Darkness,
+}
+
+/// Weapon skill metadata component.
+#[derive(Component)]
+pub struct WeaponSkill {
+    pub name: String,
+    pub tp_cost: u16,
+    pub properties: [ScProp; 2],
+}
+
+/// Spell metadata component.
+#[derive(Component)]
+pub struct Spell {
+    pub name: String,
+    pub element: Element,
+    pub cast_time: u16,
+}
+
+/// Active skillchain window for bonus damage.
+#[derive(Component)]
+pub struct SkillchainWindow {
+    pub start: f32,
+    pub end: f32,
+    pub elements: SmallVec<[Element; 4]>,
+    pub level: u8,
+}
+
+/// Active magic burst window after a skillchain.
+#[derive(Component)]
+pub struct MagicBurstWindow {
+    pub start: f32,
+    pub end: f32,
+    pub elements: SmallVec<[Element; 4]>,
+    pub level: u8,
+}
+
+/// Logged weapon skill used for chain detection.
+#[derive(Clone)]
+pub struct LoggedSkill {
+    pub time: f32,
+    pub properties: [ScProp; 2],
+}
+
+/// Recent action log resource.
+#[derive(Resource, Default)]
+pub struct ActionLog {
+    pub skills: SmallVec<[LoggedSkill; 4]>,
+}

--- a/vanadiel_rpg/game/src/combat/mod.rs
+++ b/vanadiel_rpg/game/src/combat/mod.rs
@@ -1,0 +1,5 @@
+//! Turn-based combat engine with skillchains and magic bursts.
+
+pub mod components;
+pub mod systems;
+pub mod skill_tables;

--- a/vanadiel_rpg/game/src/combat/skill_tables.rs
+++ b/vanadiel_rpg/game/src/combat/skill_tables.rs
@@ -1,0 +1,38 @@
+//! Lookup tables for weapon skills, spells, and skillchain combinations.
+
+use super::components::{Element, ScProp};
+use smallvec::smallvec;
+use smallvec::SmallVec;
+
+/// Resulting data for a skillchain pair.
+#[derive(Clone)]
+pub struct ChainResult {
+    pub level: u8,
+    pub elements: SmallVec<[Element; 4]>,
+}
+
+/// Example weapon skill property table.
+pub const WEAPON_SKILLS: &[(&str, [ScProp; 2])] = &[
+    ("Burning Blade", [ScProp::Scission, ScProp::Liquefaction]),
+    ("Flat Blade", [ScProp::Detonation, ScProp::Impaction]),
+];
+
+/// Example spell table.
+pub const SPELLS: &[(&str, Element, u16)] = &[
+    ("Fire", Element::Fire, 3),
+    ("Stone", Element::Earth, 3),
+];
+
+/// Simple lookup for two properties producing a chain.
+pub fn lookup_chain(a: ScProp, b: ScProp) -> Option<ChainResult> {
+    use ScProp::*;
+    match (a, b) {
+        (Scission, Detonation) => Some(ChainResult { level: 1, elements: smallvec![Element::Earth] }),
+        (Liquefaction, Impaction) => Some(ChainResult { level: 2, elements: smallvec![Element::Fire, Element::Light] }),
+        (Fragmentation, Gravitation) => Some(ChainResult { level: 3, elements: smallvec![Element::Dark] }),
+        (Distortion, Fusion) => Some(ChainResult { level: 3, elements: smallvec![Element::Light] }),
+        (Light, Light) => Some(ChainResult { level: 4, elements: smallvec![Element::Fire, Element::Wind, Element::Lightning, Element::Light] }),
+        (Darkness, Darkness) => Some(ChainResult { level: 4, elements: smallvec![Element::Ice, Element::Earth, Element::Water, Element::Dark] }),
+        _ => None,
+    }
+}

--- a/vanadiel_rpg/game/src/combat/systems.rs
+++ b/vanadiel_rpg/game/src/combat/systems.rs
@@ -1,0 +1,86 @@
+//! Core combat systems including skillchain detection and magic burst logic.
+
+use bevy::prelude::*;
+use smallvec::smallvec;
+
+use super::components::{ActionLog, LoggedSkill, MagicBurstWindow, SkillchainWindow};
+use super::components::{Element, ScProp};
+use super::skill_tables::lookup_chain;
+
+/// Event fired when a weapon skill is used.
+#[derive(Event)]
+pub struct WeaponSkillEvent {
+    pub properties: [ScProp; 2],
+    pub damage: u32,
+}
+
+/// Event fired when a spell finishes casting.
+#[derive(Event)]
+pub struct SpellCastEvent {
+    pub element: Element,
+    pub damage: u32,
+}
+
+/// Checks recent weapon skills for valid skillchain pairs.
+pub fn detect_skillchain(
+    mut commands: Commands,
+    mut events: EventReader<WeaponSkillEvent>,
+    mut log: ResMut<ActionLog>,
+    time: Res<Time>,
+) {
+    for ev in events.read() {
+        let now = time.elapsed_seconds();
+        log.skills.push(LoggedSkill { time: now, properties: ev.properties });
+        if log.skills.len() > 2 {
+            log.skills.remove(0);
+        }
+
+        if log.skills.len() < 2 {
+            continue;
+        }
+
+        let prev = &log.skills[log.skills.len() - 2];
+        if now - prev.time > 10.0 {
+            continue;
+        }
+
+        if let Some(result) = lookup_chain(prev.properties[1], ev.properties[0]) {
+            let sc_start = now;
+            let sc_end = now + 10.0;
+            let mb_start = now + 3.0;
+            let mb_end = mb_start + 7.0;
+            let elements = result.elements.clone();
+            commands.spawn((
+                SkillchainWindow { start: sc_start, end: sc_end, elements: elements.clone(), level: result.level },
+                MagicBurstWindow { start: mb_start, end: mb_end, elements, level: result.level },
+            ));
+        }
+    }
+}
+
+/// Applies magic burst bonuses when spells land during a burst window.
+pub fn apply_magic_burst(
+    mut commands: Commands,
+    mut events: EventReader<SpellCastEvent>,
+    mut query: Query<(Entity, &SkillchainWindow, &MagicBurstWindow)>,
+    time: Res<Time>,
+) {
+    for ev in events.read() {
+        let now = time.elapsed_seconds();
+        for (entity, sc, mb) in &mut query {
+            if now >= mb.start && now <= mb.end && mb.elements.contains(&ev.element) {
+                let multiplier = 1.3 + (sc.level as f32 * 0.2);
+                info!("Magic Burst! Damage x{multiplier:?}");
+                // Despawn window after burst.
+                commands.entity(entity).despawn_recursive();
+            }
+        }
+    }
+}
+
+// Future extensions:
+// - Track multiple sequential weapon skills in `ActionLog` to support
+//   multi-step chains and shrinking windows.
+// - Apply elemental resistance adjustments when a chain or magic burst lands.
+// - Compensate for network latency by stretching detection windows based on
+//   player equipment or traits like "SkillchainDuration+".

--- a/vanadiel_rpg/game/src/main.rs
+++ b/vanadiel_rpg/game/src/main.rs
@@ -6,6 +6,7 @@ use bevy::render::texture::ImagePlugin;
 use bevy::diagnostic::FrameTimeDiagnosticsPlugin;
 use bevy_ecs_tilemap::TilemapPlugin;
 
+mod combat;
 mod plugins {
     pub mod core;
     pub mod map;

--- a/vanadiel_rpg/game/src/plugins/combat.rs
+++ b/vanadiel_rpg/game/src/plugins/combat.rs
@@ -3,6 +3,8 @@
 use bevy::prelude::*;
 
 use super::core::GameState;
+use crate::combat::components::ActionLog;
+use crate::combat::systems::{apply_magic_burst, detect_skillchain, SpellCastEvent, WeaponSkillEvent};
 
 /// Event triggered when a random encounter occurs.
 #[derive(Event, Default)]
@@ -18,9 +20,20 @@ pub struct CombatPlugin;
 impl Plugin for CombatPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<EncounterEvent>()
+            .add_event::<WeaponSkillEvent>()
+            .add_event::<SpellCastEvent>()
+            .init_resource::<ActionLog>()
             .add_systems(Update, handle_encounter.run_if(in_state(GameState::Exploration)))
             .add_systems(OnEnter(GameState::Battle), start_battle)
-            .add_systems(Update, exit_battle.run_if(in_state(GameState::Battle)))
+            .add_systems(
+                Update,
+                (
+                    exit_battle,
+                    detect_skillchain,
+                    apply_magic_burst,
+                )
+                    .run_if(in_state(GameState::Battle)),
+            )
             .add_systems(OnExit(GameState::Battle), cleanup_battle);
     }
 }


### PR DESCRIPTION
## Summary
- add combat system modules with Skillchain and Magic Burst logic
- hook new systems into the CombatPlugin
- load example weapon skills, spells, and chain table
- scaffold a Skillchain tutorial quest

## Testing
- `scripts/pre_commit.sh` *(fails: 'cargo-fmt' not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f0e3fccfc83239f4a9147e3823cb3