### PR TITLE
Improve hardware detection

### DIFF
--- a/vanadiel_rpg/game/Cargo.toml
+++ b/vanadiel_rpg/game/Cargo.toml
@@ -14,6 +14,7 @@ rand = "0.8"
 toml = "0.8"
 smallvec = "1.11"
 once_cell = "1.19"
+sysinfo = "0.30"
 
 [features]
 default = []

--- a/vanadiel_rpg/game/src/main.rs
+++ b/vanadiel_rpg/game/src/main.rs
@@ -4,8 +4,9 @@ use bevy::window::PresentMode;
 
 mod plugins;
 use plugins::{
-    CombatPlugin, CorePlugin, InteractionPlugin as GameInteractionPlugin, LoadingPlugin,
-    LorePlugin, MapPlugin, MovementPlugin, QuestPlugin, SpritePlugin, StarterAreaPlugin, UiPlugin,
+    CombatPlugin, CorePlugin, HardwareInfoPlugin, InteractionPlugin as GameInteractionPlugin,
+    LoadingPlugin, LorePlugin, MapPlugin, MovementPlugin, QuestPlugin, SpritePlugin,
+    StarterAreaPlugin, UiPlugin,
 };
 mod combat;
 
@@ -27,6 +28,7 @@ fn main() {
         )
         .add_plugins((
             CorePlugin,
+            HardwareInfoPlugin,
             LoadingPlugin,
             MapPlugin,
             MovementPlugin,

--- a/vanadiel_rpg/game/src/plugins/hardware_info.rs
+++ b/vanadiel_rpg/game/src/plugins/hardware_info.rs
@@ -1,0 +1,27 @@
+//! Simple plugin to log CPU and GPU information on startup.
+
+use bevy::prelude::*;
+use bevy::render::renderer::RenderAdapterInfo;
+use sysinfo::{CpuExt, System, SystemExt};
+
+/// Plugin that prints basic hardware information.
+pub struct HardwareInfoPlugin;
+
+impl Plugin for HardwareInfoPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, log_hardware_info);
+    }
+}
+
+fn log_hardware_info(adapter: Res<RenderAdapterInfo>) {
+    let mut system = System::new();
+    system.refresh_cpu();
+    let cpu_brand = system
+        .cpus()
+        .first()
+        .map(|c| c.brand().to_string())
+        .unwrap_or_else(|| "Unknown CPU".to_string());
+
+    info!("Detected GPU: {}", adapter.name);
+    info!("Detected CPU: {}", cpu_brand);
+}

--- a/vanadiel_rpg/game/src/plugins/mod.rs
+++ b/vanadiel_rpg/game/src/plugins/mod.rs
@@ -1,5 +1,6 @@
 pub mod combat;
 pub mod core;
+pub mod hardware_info;
 pub mod interaction;
 pub mod loading;
 pub mod lore;
@@ -12,6 +13,7 @@ pub mod ui;
 
 pub use combat::CombatPlugin;
 pub use core::CorePlugin;
+pub use hardware_info::HardwareInfoPlugin;
 pub use interaction::InteractionPlugin;
 pub use loading::LoadingPlugin;
 pub use lore::LorePlugin;


### PR DESCRIPTION
## Summary
- add a simple hardware info plugin
- log CPU and GPU name at startup

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings` *(fails: alsa development package missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f48ef08ec8323a0e74137692a1fbc